### PR TITLE
WriteAsync instead of Write

### DIFF
--- a/src/RotativaCore/AsResultBase.cs
+++ b/src/RotativaCore/AsResultBase.cs
@@ -244,7 +244,7 @@ namespace RotativaCore
 
             var response = PrepareResponse(context.HttpContext.Response);
 
-            response.Body.Write(fileContent, 0, fileContent.Length);
+            response.Body.WriteAsync(fileContent, 0, fileContent.Length);
         }
 
         private static string SanitizeFileName(string name)


### PR DESCRIPTION
Fixes Synchronous operations are disallowed in ASP.NET Core 3.0.0 #5
No breaking changes, but a follow-up on this fix could be to have the entire process async. for performance reasons. 

Tested with ASP.NET Core 2.2 and 3.0.0 (Preview 4)